### PR TITLE
require node 16 due to adapter core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "type": "git",
     "url": "https://github.com/ioBroker/ioBroker.parser"
   },
+  "engines": {
+    "node": ">= 16"
+  },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.4",
     "axios": "^1.5.1"


### PR DESCRIPTION
This adapter requires node 16 or newer as adapter-core is known to fail with node 14 or older